### PR TITLE
fix IE10 support by upgrading exifr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -464,9 +464,9 @@
             }
         },
         "exifr": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/exifr/-/exifr-4.3.0.tgz",
-            "integrity": "sha512-AYcYsi249TcAnkdfr8TqX/zG9JmXCjLiyFAuTZFAHR1ybWay0vKnc7FCA9bCWBswMKeBIXV+FKtl94WBNCiKJA=="
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/exifr/-/exifr-4.3.4.tgz",
+            "integrity": "sha512-1pS43SxlWUy3MGsL7pNaNO6OjStAH0tr/EnqT6BJOhft4xCNsN9QyXdhap71PEF4FIm2CPOyolls8L5h++wHyg=="
         },
         "expand-brackets": {
             "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "resize"
     ],
     "dependencies": {
-        "exifr": "^4.3.0",
+        "exifr": "^4.3.4",
         "pica": ">=4.0.1"
     },
     "peerDependencies": {

--- a/src/img-exif.service.ts
+++ b/src/img-exif.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@angular/core';
-import * as exifr from 'exifr';
+import * as exifr from 'exifr/dist/mini.legacy.umd';
 
 @Injectable()
 export class ImgExifService {
     public getOrientedImage(image:HTMLImageElement):Promise<HTMLImageElement> {
         return new Promise<HTMLImageElement>(resolve => {
             let img:any;
-			exifr.orientation(image).then(orientation => {
+			exifr.orientation(image).catch(err => undefined).then(orientation => {
                 if (orientation != 1) {
                     let canvas:HTMLCanvasElement = document.createElement("canvas"),
                         ctx:CanvasRenderingContext2D = <CanvasRenderingContext2D> canvas.getContext("2d"),


### PR DESCRIPTION
Hello. I didn't notice that these modules support IE10 and in the last PR I used exifr's default build instead of legacy build which includes necessary shims for running in IE10.  This helps with the comment under https://github.com/bergben/ng2-img-max/pull/46 